### PR TITLE
Update Makefile

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,3 +7,4 @@
 # Please keep the list sorted.
 
 Jan Mercl <0xjnml@gmail.com>
+Yan Zhu <hackzhuyan@gmail.com>

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -17,7 +17,7 @@ scanner.go: demo.l
 	golex -o $@ $<
 
 parser.go: demo.y
-	go tool yacc -o $@ $<
+	goyacc -o $@ $<
 
 demo.y: demo.ebnf
 	ebnf2y -start Expression -o $@ $<


### PR DESCRIPTION
Go 1.8 removes the `go tool yacc` command
It's now at https://godoc.org/golang.org/x/tools/cmd/goyacc